### PR TITLE
Make spirit a little smaller and proper yoffset.

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -6,9 +6,9 @@
    "copyright": "Artwork Copyright (C) Kirigakure",
    "actions": {
 	   "default": {
-          "xoff":0,
-	      "yoff": 10,
-	      "scale": 50
+              "xoff": -120,
+	      "yoff": 340,
+	      "scale": 22
 	   }
    }
 }


### PR DESCRIPTION
You see the yoffset is based on the original size of the image and not the scaled version. Since your original image is 1000x1000, so the proper yoffset should be 340-400 pixels, so I gave 340 px as the yoffset which works great. Also xoffset is needed to correctly place the action when it is placed on top left.

![ivon](https://user-images.githubusercontent.com/33930174/204348234-4e910936-f926-4c08-963a-0aac8fff8580.png)
